### PR TITLE
Fix production Firebase deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,4 +46,4 @@ jobs:
           echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-service-account.json" >> "$GITHUB_ENV"
 
       - name: Deploy to Firebase
-        run: npm run deploy -- --project maranchello-website
+        run: npm run deploy:hosting -- --project maranchello-website

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "nuxt preview",
     "test": "nuxt prepare && vitest run",
     "typecheck": "nuxt typecheck",
-    "deploy": "npm run generate && firebase deploy --non-interactive"
+    "deploy": "npm run generate && firebase deploy --non-interactive",
+    "deploy:hosting": "npm run generate && firebase deploy --only hosting --non-interactive"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.2.0",


### PR DESCRIPTION
## Summary
- Scope the production GitHub Actions deploy to Firebase Hosting only
- Add a dedicated npm script for Hosting-only deploys while leaving the full Firebase deploy script available for manual rules deploys

## Verification
- npm run test
- npm run typecheck
- GOOGLE_APPLICATION_CREDENTIALS=/Users/franmaranchello/Downloads/maranchello-website-firebase-adminsdk-qtf91-b9bf50a1f9.json npm run deploy:hosting -- --project maranchello-website --dry-run